### PR TITLE
Small refactors so this plugin works with OpenJDK

### DIFF
--- a/src/main/java/com/cmeza/sdgenerator/support/maker/builder/ObjectStructure.java
+++ b/src/main/java/com/cmeza/sdgenerator/support/maker/builder/ObjectStructure.java
@@ -5,7 +5,7 @@ import com.cmeza.sdgenerator.support.maker.values.ObjectTypeValues;
 import com.cmeza.sdgenerator.support.maker.values.ObjectValues;
 import com.cmeza.sdgenerator.support.maker.values.ScopeValues;
 import com.cmeza.sdgenerator.util.BuildUtils;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
@@ -247,7 +247,7 @@ public class ObjectStructure {
         }
 
         public ObjectConstructor addArgument(String argumentClass, String argumentName) {
-            constructorArguments.add(new Pair<>(BuildUtils.cleanSpaces(argumentClass), BuildUtils.cleanSpaces(argumentName)));
+            constructorArguments.add(Pair.of(BuildUtils.cleanSpaces(argumentClass), BuildUtils.cleanSpaces(argumentName)));
             return this;
         }
 
@@ -325,7 +325,7 @@ public class ObjectStructure {
         }
 
         public ObjectFunction addArgument(String argumentClass, String argumentName) {
-            functionArguments.add(new Pair<>(BuildUtils.cleanSpaces(argumentClass), BuildUtils.cleanSpaces(argumentName)));
+            functionArguments.add(Pair.of(BuildUtils.cleanSpaces(argumentClass), BuildUtils.cleanSpaces(argumentName)));
             return this;
         }
 
@@ -410,7 +410,7 @@ public class ObjectStructure {
         }
 
         public ObjectMethod addArgument(String argumentClass, String argumentName) {
-            methodArguments.add(new Pair<>(BuildUtils.cleanSpaces(argumentClass), BuildUtils.cleanSpaces(argumentName)));
+            methodArguments.add(Pair.of(BuildUtils.cleanSpaces(argumentClass), BuildUtils.cleanSpaces(argumentName)));
             return this;
         }
 

--- a/src/main/java/com/cmeza/sdgenerator/util/BuildUtils.java
+++ b/src/main/java/com/cmeza/sdgenerator/util/BuildUtils.java
@@ -4,7 +4,7 @@ import com.cmeza.sdgenerator.support.maker.values.CommonValues;
 import com.cmeza.sdgenerator.support.maker.values.ExpressionValues;
 import com.cmeza.sdgenerator.support.maker.values.ObjectValues;
 import com.cmeza.sdgenerator.support.maker.values.ScopeValues;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Set;
 


### PR DESCRIPTION
This solves #20 

There were some uses of `javafx.util.Pair` which is not included in
OpenJDK.

Since you were already using Apache commons-lang3, I replaced
`javafx.util.Pair` uses with `org.apache.commons.lang3.tuple.Pair` which is
pretty much the same (maybe even better, it's immutable).

Tested generating repositories and managers on a project I'm working on,
using OpenJDK 1.8.0_172.